### PR TITLE
Fix typo on e_RelayDriverChannels declaration

### DIFF
--- a/include/relay-exp.h
+++ b/include/relay-exp.h
@@ -16,7 +16,7 @@ typedef enum e_RelayDriverChannels {
 	RELAY_EXP_CHANNEL0 		= 0,
 	RELAY_EXP_CHANNEL1,
 	RELAY_EXP_NUM_CHANNELS,
-} ePwmDriverAddr;
+} eRelayDriverChannels;
 
 
 int 	relayDriverInit 		(int addr);


### PR DESCRIPTION
It conflicts with the typedef declaration in pwm-exp.h
