### PR TITLE
Fix #8 segmentation fault on long parameters.

### DIFF
--- a/src/main-oled-exp.c
+++ b/src/main-oled-exp.c
@@ -216,8 +216,8 @@ int main(int argc, char** argv)
 	clear 		= 0;
 	verbose 	= ONION_VERBOSITY_NORMAL;
 
-	command 	= malloc(255 * sizeof *command);
-	param 		= malloc(255 * sizeof *param);
+	command 	= malloc(MAX_COMMAND_LENGTH * sizeof *command);
+	param 		= malloc(MAX_PARAM_LENGTH * sizeof *param);
 
 	// save the program name
 	progname 	= argv[0];	
@@ -298,6 +298,12 @@ int main(int argc, char** argv)
 
 	//// parse the command arguments
 	while ( argc > 0 ) {
+		if(strlen(argv[0]) > MAX_COMMAND_LENGTH || strlen(argv[1]) > MAX_PARAM_LENGTH) {
+			// FIXME: This error needs rewording. Also, the exit status should be less funny.
+			onionPrint(ONION_SEVERITY_FATAL, "Unsupported parameter length\n");
+			exit(13);
+		}
+		
 		// first arg - command
 		strcpy(command, argv[0]);
 


### PR DESCRIPTION
<rant>
Somebody *cough, cough* thought that 255 characters would be enough to fit a 2054 byte string.
The draw command with a data: input did not work.
</rant>

I do these things sometimes. Anybody can have a little error. ;-)